### PR TITLE
Handle f64 numbers on 32 bit systems

### DIFF
--- a/intl_pluralrules/src/operands.rs
+++ b/intl_pluralrules/src/operands.rs
@@ -59,15 +59,15 @@ pub struct PluralOperands {
     /// Absolute value of input
     pub n: f64,
     /// Integer value of input
-    pub i: usize,
+    pub i: u64,
     /// Number of visible fraction digits with trailing zeros
     pub v: usize,
     /// Number of visible fraction digits without trailing zeros
     pub w: usize,
     /// Visible fraction digits with trailing zeros
-    pub f: usize,
+    pub f: u64,
     /// Visible fraction digits without trailing zeros
-    pub t: usize,
+    pub t: u64,
 }
 
 impl<'a> TryFrom<&'a str> for PluralOperands {
@@ -93,17 +93,17 @@ impl<'a> TryFrom<&'a str> for PluralOperands {
             let dec_str = &abs_str[(dec_pos + 1)..];
 
             integer_digits =
-                usize::from_str(&int_str).map_err(|_| "Could not convert string to integer!")?;
+                u64::from_str(&int_str).map_err(|_| "Could not convert string to integer!")?;
 
             let backtrace = dec_str.trim_end_matches('0');
 
             num_fraction_digits0 = dec_str.len() as usize;
             num_fraction_digits = backtrace.len() as usize;
             fraction_digits0 =
-                usize::from_str(dec_str).map_err(|_| "Could not convert string to integer!")?;
-            fraction_digits = usize::from_str(backtrace).unwrap_or(0);
+                u64::from_str(dec_str).map_err(|_| "Could not convert string to integer!")?;
+            fraction_digits = u64::from_str(backtrace).unwrap_or(0);
         } else {
-            integer_digits = absolute_value as usize;
+            integer_digits = absolute_value as u64;
             num_fraction_digits0 = 0;
             num_fraction_digits = 0;
             fraction_digits0 = 0;
@@ -128,7 +128,7 @@ macro_rules! impl_integer_type {
                 // XXXManishearth converting from u32 or u64 to isize may wrap
                 PluralOperands {
                     n: input as f64,
-                    i: input as usize,
+                    i: input as u64,
                     v: 0,
                     w: 0,
                     f: 0,
@@ -151,7 +151,7 @@ macro_rules! impl_signed_integer_type {
                 let x = (input as isize).checked_abs().ok_or("Number too big")?;
                 Ok(PluralOperands {
                     n: x as f64,
-                    i: x as usize,
+                    i: x as u64,
                     v: 0,
                     w: 0,
                     f: 0,

--- a/intl_pluralrules/tests/operands.rs
+++ b/intl_pluralrules/tests/operands.rs
@@ -116,7 +116,7 @@ fn custom_type() {
         fn try_into(self) -> Result<PluralOperands, Self::Error> {
             Ok(PluralOperands {
                 n: self.value as f64,
-                i: self.value as usize,
+                i: self.value as u64,
                 v: 0,
                 w: 0,
                 f: 0,
@@ -130,4 +130,11 @@ fn custom_type() {
     let v = MyType { value: 5 };
 
     assert_eq!(pr.select(v), Ok(PluralCategory::OTHER));
+}
+
+#[test]
+fn many_decimal_places() {
+    // this should not panic on an i32 system
+    let num: f64 = 2.813829837982735;
+    assert_eq!(dbg!(PluralOperands::try_from(num)).is_ok(), true);
 }


### PR DESCRIPTION
This is a lower-level way to solve https://github.com/projectfluent/fluent-rs/pull/162

The way I prefer it is that it fixes it on the right level, making this crate work for both 64bit and 32bit rather than fixing it in the consumer of this crate.

There is of course no penalty on 64bit, while on 32 bit there is a 2x perf hit on selection:

```
select/31               time:   [704.63 ns 709.34 ns 714.61 ns]                       
                        change: [+109.25% +111.88% +114.15%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

```

I think it is an ok hit to accept. 32bit machines are rare and the benefit of having a stable system is outweighing the perf cost.

@Manishearth - can you review?