### PR TITLE
actually include license files in published intl_pluralrules crates

### DIFF
--- a/intl_pluralrules/Cargo.toml
+++ b/intl_pluralrules/Cargo.toml
@@ -13,7 +13,8 @@ include = [
 	"src/**/*",
 	"benches/*.rs",
 	"Cargo.toml",
-	"README.md"
+	"README.md",
+	"LICENSE-*",
 ]
 
 [badges]


### PR DESCRIPTION
The files were added in this PR: https://github.com/zbraniecki/pluralrules/pull/38

But they weren't actually subsequently included in published crates, because the list of included files in Cargo.toml wasn't updated to include them.